### PR TITLE
Demonstrate data streams

### DIFF
--- a/LivekitUnitySampleApp/Assets/LivekitSamples.cs
+++ b/LivekitUnitySampleApp/Assets/LivekitSamples.cs
@@ -98,10 +98,6 @@ public class LivekitSamples : MonoBehaviour
             var connect = room.Connect(url, token, options);
             yield return connect;
 
-            room.RegisterTextStreamHandler("my-topic", (data, identity) =>
-                StartCoroutine(HandleTextStream(data, identity))
-            );
-
             if (!connect.IsError)
             {
                 Debug.Log("Connected to " + room.Name);


### PR DESCRIPTION
**Summary of changes**:
- Adds text stream handler for "some-topic", logs incoming messages
- Uses send text instead of publish data for sending messages

Depends on data streams support introduced in livekit/client-sdk-unity#89.